### PR TITLE
Fix for `TypeError` caused by unicode issues.

### DIFF
--- a/cheetah/Version.py
+++ b/cheetah/Version.py
@@ -1,5 +1,5 @@
 Version = '2.4.4'
-VersionTuple = (2, 4, 4, 'development', 0)
+VersionTuple = (2, 4, 4, 'development', 1)
 
 MinCompatibleVersion = '2.0rc6'
 MinCompatibleVersionTuple = (2, 0, 0, 'candidate', 6)

--- a/cheetah/convertTmplPathToModuleName.py
+++ b/cheetah/convertTmplPathToModuleName.py
@@ -17,4 +17,8 @@ def convertTmplPathToModuleName(tmplPath,
                                 _pathNameTransChars=_pathNameTransChars,
                                 splitdrive=os.path.splitdrive,
                                 ):
-    return splitdrive(tmplPath)[1].translate(_pathNameTransChars)
+    try:
+        moduleName = splitdrive(tmplPath)[1].translate(_pathNameTransChars)
+    except (UnicodeError, TypeError):
+        moduleName = unicode(splitdrive(tmplPath)[1]).translate(unicode(_pathNameTransChars))
+    return moduleName


### PR DESCRIPTION
Hi,

This fixes the following error:

```
moduleName = splitdrive(tmplPath)[1].translate(_pathNameTransChars)
TypeError: character mapping must return integer, None or unicode
```

I got this error while using [poni](https://github.com/melor/poni).

Thanks
Lakshmi.
