### PR TITLE
Avoid creating an invalid class name

### DIFF
--- a/cheetah/Template.py
+++ b/cheetah/Template.py
@@ -644,7 +644,7 @@ class Template(Servlet):
 
         if not isinstance(className, (types.NoneType, basestring)):
             raise TypeError(errmsg % ('className', 'string or None'))
-        className = re.sub(r'^_+','', className or moduleName)
+        className = re.sub(r'^_+([^0-9])',r'\1', className or moduleName)
 
         if mainMethodName is Unspecified:
             mainMethodName = klass._CHEETAH_defaultMainMethodNameForTemplates


### PR DESCRIPTION
Avoid creating an invalid class name for the file on the path where the first folder name starts with a number, e.g. c:\10folder\code\sample.tmpl.
