### PR TITLE
Bump version to 2.4.5

### DIFF
--- a/cheetah/Version.py
+++ b/cheetah/Version.py
@@ -1,5 +1,5 @@
-Version = '2.4.4'
-VersionTuple = (2, 4, 4, 'development', 1)
+Version = '2.4.5'
+VersionTuple = (2, 4, 5, 'development', 1)
 
 MinCompatibleVersion = '2.0rc6'
 MinCompatibleVersionTuple = (2, 0, 0, 'candidate', 6)


### PR DESCRIPTION
It looks like commit 86229c1 corresponds to the
2.4.4 release, but there's no tag.

Change the version in git to 2.4.5 to make it
clear it's an unreleased version.
