### PR TITLE
Initial cleanup for python3

### DIFF
--- a/SetupConfig.py
+++ b/SetupConfig.py
@@ -14,8 +14,8 @@ packages = ['Cheetah',
             'Cheetah.Tools',
             'Cheetah.Utils',
             ]
-classifiers = [line.strip() for line in '''\
-  #Development Status :: 4 - Beta
+classifiers = [line.strip() for line in
+'''#Development Status :: 4 - Beta
   Development Status :: 5 - Production/Stable
   Intended Audience :: Developers
   Intended Audience :: System Administrators
@@ -29,7 +29,9 @@ classifiers = [line.strip() for line in '''\
   Topic :: Software Development :: Libraries :: Python Modules
   Topic :: Software Development :: User Interfaces
   Topic :: Text Processing'''.splitlines() if not line.strip().startswith('#')]
-del line
+
+if sys.version_info.major == 2:
+  del line
 
 package_dir = {'Cheetah':'cheetah'}
 

--- a/SetupTools.py
+++ b/SetupTools.py
@@ -47,13 +47,13 @@ class mod_build_ext(build_ext):
     def run(self):
         try:
             build_ext.run(self)
-        except DistutilsPlatformError, x:
+        except DistutilsPlatformError as x:
             raise BuildFailed(x)
 
     def build_extension(self, ext):
         try:
             build_ext.build_extension(self, ext)
-        except ext_errors, x:
+        except ext_errors as x:
             raise BuildFailed(x)
 
    
@@ -156,7 +156,7 @@ def run_setup(configurations):
     # Invoke distutils setup
     try:
         setup(**kws)
-    except BuildFailed, x:
+    except BuildFailed as x:
         print("One or more C extensions failed to build.")
         print("Details: %s" % x)
         if os.environ.get('CHEETAH_C_EXTENSIONS_REQUIRED'):
@@ -169,4 +169,3 @@ def run_setup(configurations):
         print("One or more C extensions failed to build.")
         print("Performance enhancements will not be available.")
         print("Pure Python installation succeeded.")
-

--- a/cheetah/__init__.py
+++ b/cheetah/__init__.py
@@ -17,4 +17,4 @@ Subscribe at
     http://lists.sourceforge.net/lists/listinfo/cheetahtemplate-discuss
 '''
 
-from Version import *
+from .Version import *


### PR DESCRIPTION
Just some initial top level stuff to get going in the direction of python3 support.  Still need more before 2to3 works.  e.g. 

2to3 .
[snip]

RefactoringTool: ./www/conf.py
RefactoringTool: Warnings/messages while refactoring:
RefactoringTool: ### In file ./build/lib.linux-x86_64-2.7/Cheetah/Parser.py ###
RefactoringTool: Line 346: cannot convert map(None, ...) with multiple arguments because map() now truncates to the shortest sequence
RefactoringTool: Line 346: cannot convert map(None, ...) with multiple arguments because map() now truncates to the shortest sequence
RefactoringTool: ### In file ./cheetah/Parser.py ###
RefactoringTool: Line 346: cannot convert map(None, ...) with multiple arguments because map() now truncates to the shortest sequence
RefactoringTool: Line 346: cannot convert map(None, ...) with multiple arguments because map() now truncates to the shortest sequence
