### PR TITLE
Add support for tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build
 *.py.bak
 Cheetah.egg-info/
 dist
+.eggs/
+.tox/

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, py32, py33, py34, pypy
+
+[testenv]
+commands = python cheetah/Tests/Test.py
+deps =
+    py26: --allow-external=elementtree
+    py26: --allow-unverified=elementtree
+    py26: elementtree
+    py26: importlib
+    pygments
+    pytest


### PR DESCRIPTION
```
$ pip install tox
...
$ tox
...
  py26: commands succeeded
  py27: commands succeeded
ERROR:   py32: InvocationError: /Users/marca/dev/git-repos/cheetah/.tox/py32/bin/pip install -U --no-deps /Users/marca/dev/git-repos/cheetah/.tox/dist/Cheetah-2.4.4.zip (see /Users/marca/dev/git-repos/cheetah/.tox/py32/log/py32-3.log)
ERROR:   py33: InvocationError: /Users/marca/dev/git-repos/cheetah/.tox/py33/bin/pip install -U --no-deps /Users/marca/dev/git-repos/cheetah/.tox/dist/Cheetah-2.4.4.zip (see /Users/marca/dev/git-repos/cheetah/.tox/py33/log/py33-3.log)
ERROR:   py34: InvocationError: /Users/marca/dev/git-repos/cheetah/.tox/py34/bin/pip install -U --no-deps /Users/marca/dev/git-repos/cheetah/.tox/dist/Cheetah-2.4.4.zip (see /Users/marca/dev/git-repos/cheetah/.tox/py34/log/py34-3.log)
  pypy: commands succeeded
```
